### PR TITLE
feat: add q_date_recent metric

### DIFF
--- a/data_metrics/manifest.toml
+++ b/data_metrics/manifest.toml
@@ -9,6 +9,7 @@ file_names = [
     "c_resources_per_pt/c_resources_per_pt.py",
     "c_term_coverage/c_term_coverage.py",
     "c_us_core_v4_count/c_us_core_v4_count.py",
+    "q_date_recent/q_date_recent.py",
     "q_ref_target_pop/q_ref_target_pop.py",
     "q_ref_target_valid/q_ref_target_valid.py",
     "q_term_use/q_term_use.py",

--- a/data_metrics/meta/dates.jinja
+++ b/data_metrics/meta/dates.jinja
@@ -14,6 +14,7 @@ dates_{{ resource }} AS (
   LEFT JOIN status_{{ resource }} AS status
   ON status.id = src.id
   WHERE
+      -- If you change this status logic, consider if q_date_recent needs the same change.
       status.status IS NULL
       OR (
           status.status <> 'entered-in-error'

--- a/data_metrics/q_date_recent/README.md
+++ b/data_metrics/q_date_recent/README.md
@@ -1,0 +1,34 @@
+# q_date_recent
+
+**Are dates in the plausibly "recent" past?**
+
+### Numerator (flagged rows)
+
+Any row for which any of its date fields are outside our target range.
+
+The earliest a date can still be "plausible" is 1900-01-01
+(which is arbitrary, but BCH sees reasonable dates as far back as 1915
+for backdated near-birth events like allergy onsets).
+
+The latest a date can be is the current time.
+
+Rows with an `entered-in-error` status
+(or Encounters with a `planned` status)
+are ignored.
+
+### Denominator
+
+All possible rows for the resource in question.
+
+(e.g. `count(*) from condition`)
+
+### Debugging
+
+Each resource/field combo creates a table full of each row
+that was flagged as an issue.
+
+For example, for `Condition.subject` a table named
+`data_metrics__q_date_recent_condition` is created.
+
+These tables hold the `id`, `status`, and date fields for each flagged row,
+to aid root cause analysis.

--- a/data_metrics/q_date_recent/q_date_recent.jinja
+++ b/data_metrics/q_date_recent/q_date_recent.jinja
@@ -1,0 +1,41 @@
+{% import 'utils.jinja' as utils %}
+
+CREATE TABLE data_metrics__q_date_recent_{{ src|lower }} AS (
+WITH
+src_status AS {{ utils.extract_status(src) }}
+
+SELECT
+    src.id,
+
+    {% for field in fields %}
+    src.{{ field }} AS {{ field|replace('.', '_')|lower }},
+    {% endfor %}
+
+    src_status.status
+FROM {{ src }} AS src
+LEFT JOIN src_status
+ON src_status.id = src.id
+WHERE
+    (
+        -- Check status, because it's not fair to ding error rows (or planned encounters)
+        -- If you change this logic, consider if meta/dates.jinja needs the same change.
+        src_status.status IS NULL
+        OR (
+            src_status.status <> 'entered-in-error'
+            {% if src == 'Encounter' %}
+            AND src_status.status <> 'planned'
+            {% endif %}
+        )
+    ) AND (
+        -- Check date range. 1900 is arbitrary and maybe should be customizable per-site.
+        -- BCH was seeing valid dates as far back as 1915 (allergy onset at age 3 for a 1912
+        -- birthDate).
+        FALSE
+        {% for field in fields %}
+        OR (
+            {{ field }} IS NOT NULL
+            AND {{ utils.get_date([field]) }} NOT BETWEEN DATE('1900-01-01') AND CURRENT_DATE
+        )
+        {% endfor %}
+    )
+);

--- a/data_metrics/q_date_recent/q_date_recent.py
+++ b/data_metrics/q_date_recent/q_date_recent.py
@@ -1,0 +1,24 @@
+"""
+Module for generating q_date_recent tables
+
+https://github.com/sync-for-science/qualifier/blob/master/metrics.md#q_date_recent-plausibility-expect-date-to-be-in-recent-past
+"""
+
+from cumulus_library.base_table_builder import BaseTableBuilder
+from data_metrics.base import MetricMixin
+
+
+class DateRecentBuilder(MetricMixin, BaseTableBuilder):
+    name = "q_date_recent"
+
+    def make_table(self, **kwargs) -> None:
+        """Make a single metric table"""
+        summary_key = kwargs['src'].lower()
+        self.summary_entries[summary_key] = None
+
+        self.queries.append(self.render_sql(self.name, **kwargs))
+
+    def prepare_queries(self, *args, **kwargs) -> None:
+        for src, fields in self.DATE_FIELDS.items():
+            self.make_table(src=src, fields=fields)
+        self.make_summary()

--- a/tests/data/q_date_recent/general/condition/0.ndjson
+++ b/tests/data/q_date_recent/general/condition/0.ndjson
@@ -1,0 +1,4 @@
+{"id": "multiple-with-invalid-recorded", "recordedDate": "1899", "onsetDateTime": "2000"}
+{"id": "multiple-with-invalid-onset", "recordedDate": "2000", "onsetDateTime": "1899"}
+{"id": "multiple-valid", "recordedDate": "2000", "onsetDateTime": "2000"}
+{"id": "nothing"}

--- a/tests/data/q_date_recent/general/encounter/0.ndjson
+++ b/tests/data/q_date_recent/general/encounter/0.ndjson
@@ -1,0 +1,4 @@
+{"id": "valid", "period": {"start": "2000", "end": "9999"}}
+{"id": "future", "status": "finished", "period": {"start": "9999"}}
+{"id": "future-planned", "status": "planned", "period": {"start": "9999"}}
+{"id": "nothing"}

--- a/tests/data/q_date_recent/general/expected_condition.csv
+++ b/tests/data/q_date_recent/general/expected_condition.csv
@@ -1,0 +1,3 @@
+id,recordeddate,onsetdatetime,onsetperiod_start,status
+multiple-with-invalid-recorded,1899,2000,,
+multiple-with-invalid-onset,2000,1899,,

--- a/tests/data/q_date_recent/general/expected_encounter.csv
+++ b/tests/data/q_date_recent/general/expected_encounter.csv
@@ -1,0 +1,2 @@
+id,period_start,status
+future,9999,finished

--- a/tests/data/q_date_recent/general/expected_procedure.csv
+++ b/tests/data/q_date_recent/general/expected_procedure.csv
@@ -1,0 +1,3 @@
+id,performeddatetime,performedperiod_start,status
+past,,1899,
+future,9999,,

--- a/tests/data/q_date_recent/general/expected_summary.csv
+++ b/tests/data/q_date_recent/general/expected_summary.csv
@@ -1,0 +1,10 @@
+id,numerator,denominator,percentage
+procedure,2,5,40.00%
+observation,0,0,0%
+medicationrequest,0,0,0%
+immunization,0,0,0%
+encounter,1,4,25.00%
+documentreference,0,0,0%
+diagnosticreport,0,0,0%
+condition,2,4,50.00%
+allergyintolerance,0,0,0%

--- a/tests/data/q_date_recent/general/procedure/0.ndjson
+++ b/tests/data/q_date_recent/general/procedure/0.ndjson
@@ -1,0 +1,5 @@
+{"id": "valid", "performedDateTime": "1900-01-01T00:00:00Z"}
+{"id": "past", "performedPeriod": {"start": "1899"}}
+{"id": "future", "performedDateTime": "9999"}
+{"id": "error", "performedPeriod": {"start": "1899"}, "status": "entered-in-error"}
+{"id": "nothing"}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -41,6 +41,9 @@ class MetricsTestCase(unittest.TestCase):
         # Just spot checks one resource - the main logic is tested in t_us_core_v4
         self.run_study("c_us_core_v4_count", prefix="count_")
 
+    def test_q_date_recent(self):
+        self.run_study("q_date_recent")
+
     def test_q_ref_target_pop(self):
         self.run_study("q_ref_target_pop")
 


### PR DESCRIPTION
This checks for plausibility of all date fields.

That is, it flags any rows with dates older than 1900 and newer than the current time.