### PR TITLE
feat: support a few more date fields

### DIFF
--- a/data_metrics/c_pt_deceased_count/c_pt_deceased_count.py
+++ b/data_metrics/c_pt_deceased_count/c_pt_deceased_count.py
@@ -7,6 +7,6 @@ from data_metrics.base import MetricMixin
 class DeceasedCountBuilder(MetricMixin, BaseTableBuilder):
     name = "c_pt_deceased_count"
 
-    def prepare_queries(self, *args, **kwargs) -> None:
+    def add_metric_queries(self, *args, **kwargs) -> None:
         # https://github.com/sync-for-science/qualifier/blob/master/metrics.md#c_pt_deceased_count-demographics-count-of-deceased-patients-by-gender-by-age-at-death
         self.queries = [self.render_sql(self.name)]

--- a/data_metrics/c_resource_count/c_resource_count.py
+++ b/data_metrics/c_resource_count/c_resource_count.py
@@ -13,14 +13,14 @@ class ResourceCountBuilder(MetricMixin, BaseTableBuilder):
 
     def make_tables(self, **kwargs) -> None:
         """Make metric tables"""
-        if kwargs["src"] in self.DATE_FIELDS:
+        if kwargs["src"] in self.date_fields:
             self.queries.append(self.render_sql(self.name, period="month", **kwargs))
             self.queries.append(self.render_sql(self.name, period="year", **kwargs))
         else:
             # no date fields, so don't do separate periods
             self.queries.append(self.render_sql(self.name, period="all", **kwargs))
 
-    def prepare_queries(self, *args, **kwargs) -> None:
+    def add_metric_queries(self) -> None:
         # https://github.com/sync-for-science/qualifier/blob/master/metrics.md#c_resource_count-volume-count-of-unique-resources-by-resource-type-by-category-by-year-by-month
         self.make_tables(
             src="AllergyIntolerance",

--- a/data_metrics/c_resources_per_pt/c_resources_per_pt.jinja
+++ b/data_metrics/c_resources_per_pt/c_resources_per_pt.jinja
@@ -4,7 +4,7 @@ CREATE TABLE data_metrics__c_resources_per_pt_summary AS (
 
 WITH
 patient_refs AS (
-    SELECT
+    SELECT DISTINCT
       concat('Patient/', id) AS ref
     FROM patient
 ),
@@ -14,7 +14,7 @@ grouped_counts AS (
     SELECT
         patient_refs.ref AS patient,
         '{{ resource }}' AS resource,
-        COUNT(src.id) AS num_resources
+        COUNT(DISTINCT src.id) AS num_resources
     FROM patient_refs
     LEFT JOIN {{ resource }} AS src
     ON patient_refs.ref = src.{{ params['field'] }}.reference

--- a/data_metrics/c_term_coverage/c_term_coverage.py
+++ b/data_metrics/c_term_coverage/c_term_coverage.py
@@ -14,7 +14,7 @@ class TermCoverageBuilder(MetricMixin, BaseTableBuilder):
         """Make a single metric table"""
         self.queries.append(self.render_sql(self.name, **kwargs))
 
-    def prepare_queries(self, *args, **kwargs) -> None:
+    def add_metric_queries(self) -> None:
         # https://github.com/sync-for-science/qualifier/blob/master/metrics.md#c_term_coverage-terminology-count-of-resources-by-terminology-system-by-resource-type-by-category
         # With some tweaks:
         # - Also stratify by year

--- a/data_metrics/meta/meta.py
+++ b/data_metrics/meta/meta.py
@@ -10,7 +10,7 @@ class MetadataBuilder(MetricMixin, BaseTableBuilder):
     def add_date_query(self) -> None:
         # This is just a mapping of *START* dates - no mechanism for looking up end dates in
         # periods. But that's ... fine. Across the whole dataset, that's a small difference.
-        self.queries.append(self.render_sql("dates", src_dates=self.DATE_FIELDS))
+        self.queries.append(self.render_sql("dates", src_dates=self.date_fields))
 
     def add_version_query(self) -> None:
         self.queries.append(self.render_sql("version"))

--- a/data_metrics/q_date_recent/q_date_recent.py
+++ b/data_metrics/q_date_recent/q_date_recent.py
@@ -18,7 +18,7 @@ class DateRecentBuilder(MetricMixin, BaseTableBuilder):
 
         self.queries.append(self.render_sql(self.name, **kwargs))
 
-    def prepare_queries(self, *args, **kwargs) -> None:
-        for src, fields in self.DATE_FIELDS.items():
+    def add_metric_queries(self) -> None:
+        for src, fields in self.date_fields.items():
             self.make_table(src=src, fields=fields)
         self.make_summary()

--- a/data_metrics/q_ref_target_pop/q_ref_target_pop.py
+++ b/data_metrics/q_ref_target_pop/q_ref_target_pop.py
@@ -18,7 +18,7 @@ class TargetPopBuilder(MetricMixin, BaseTableBuilder):
 
         self.queries.append(self.render_sql(self.name, **kwargs))
 
-    def prepare_queries(self, *args, **kwargs) -> None:
+    def add_metric_queries(self) -> None:
         # https://github.com/sync-for-science/qualifier/blob/master/metrics.md#q_ref_target_pop-conformance-expect-reference-target-to-be-populated
         self.make_table(src="AllergyIntolerance", dest="Patient", field="patient"),
         self.make_table(src="Condition", dest="Patient", field="subject"),

--- a/data_metrics/q_ref_target_valid/q_ref_target_valid.py
+++ b/data_metrics/q_ref_target_valid/q_ref_target_valid.py
@@ -9,9 +9,9 @@ class TargetValidBuilder(MetricMixin, BaseTableBuilder):
 
     uses_fields = {
         "DocumentReference": {
-            "context": [
-                "encounter",
-            ],
+            "context": {
+                "encounter": {},
+            },
         },
     }
 

--- a/data_metrics/q_term_use/q_term_use.py
+++ b/data_metrics/q_term_use/q_term_use.py
@@ -18,7 +18,7 @@ class TermUseBuilder(MetricMixin, BaseTableBuilder):
 
         self.queries.append(self.render_sql(self.name, **kwargs))
 
-    def prepare_queries(self, *args, **kwargs) -> None:
+    def add_metric_queries(self) -> None:
         # https://github.com/sync-for-science/qualifier/blob/master/metrics.md#q_term_use-conformance-expect-common-terminology-systems-to-be-populated
         # With some differences:
         # - Allow multiple systems (pulled from US Core v4 profile recommendations)

--- a/data_metrics/q_valid_us_core_v4/q_valid_us_core_v4.py
+++ b/data_metrics/q_valid_us_core_v4/q_valid_us_core_v4.py
@@ -14,6 +14,6 @@ class ValidUsCoreV4Builder(UsCoreV4Mixin, BaseTableBuilder):
         self.summary_entries[profile_name] = self.render_sql("../us_core_v4/slice", **kwargs)
         self.queries.append(self.render_sql(self.name, **kwargs))
 
-    def prepare_queries(self, *args, **kwargs) -> None:
-        super().prepare_queries(*args, **kwargs)
+    def add_metric_queries(self) -> None:
+        super().add_metric_queries()
         self.make_summary()

--- a/data_metrics/us_core_v4/documentreference_must_support.jinja
+++ b/data_metrics/us_core_v4/documentreference_must_support.jinja
@@ -66,9 +66,22 @@ tmp_simplified AS (
         ) AS valid_encounter,
 
         (
-            {% if schema["context"]["period"] %}
-            -- could call is_period_valid(), but would need to confirm each subfield exists
+            {# This is basically is_period_valid() with schema-checking, since unlike most,
+               this one period is a deeply nested field that our schema does not guarantee #}
+            {% set period_schema = schema["context"]["period"] %}
+            {% if period_schema["start"] or period_schema["end"] %}
             context.period IS NOT NULL
+            AND (
+                {% if period_schema["start"] %}
+                context.period.start IS NOT NULL
+                {% endif %}
+                {% if period_schema["start"] and period_schema["end"] %}
+                OR
+                {% endif %}
+                {% if period_schema["end"] %}
+                context.period."end" IS NOT NULL
+                {% endif %}
+            )
             {% else %}
             FALSE
             {% endif %}

--- a/data_metrics/us_core_v4/profiles.py
+++ b/data_metrics/us_core_v4/profiles.py
@@ -20,10 +20,13 @@ class UsCoreV4Mixin(MetricMixin):
                 "attachment",
                 "format",
             ],
-            "context": [
-                "encounter",
-                "period",
-            ],
+            "context": {
+                "encounter": {},
+                "period": {
+                    "start": {},
+                    "end": {},
+                },
+            },
         },
         "Encounter": {
             "hospitalization": [

--- a/tests/data/c_resource_count/general/diagnosticreport/0.ndjson
+++ b/tests/data/c_resource_count/general/diagnosticreport/0.ndjson
@@ -1,4 +1,5 @@
 {"id": "with-date", "category": [{"coding": [{"code": "CT", "system": "http://terminology.hl7.org/CodeSystem/v2-0074"}]}], "effectiveDateTime": "2023-10-04"}
+{"id": "with-issued", "issued": "2021-02-15", "status": "partial"}
 {"id": "no-date", "category": [{"coding": [{"code": "CT", "system": "http://loinc.org"}]}]}
 {"id": "unrelated-category", "category": [{"coding": [{"code": "1234", "system": "nope"}]}]}
 {"id": "no-category", "effectivePeriod": {"start": "2022-09-04"}}

--- a/tests/data/c_resource_count/general/documentreference/0.ndjson
+++ b/tests/data/c_resource_count/general/documentreference/0.ndjson
@@ -1,4 +1,5 @@
 {"id": "with-date", "category": [{"coding": [{"code": "clinical-note", "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category"}]}], "date": "2023-10-04"}
+{"id": "with-period", "context": {"period": {"start": "2020-11-04"}}, "status": "superseded"}
 {"id": "no-date", "category": [{"coding": [{"code": "clinical-note", "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category"}]}]}
 {"id": "unrelated-category", "category": [{"coding": [{"code": "1234", "system": "nope"}]}]}
 {"id": "no-category", "date": "2022-09-04"}

--- a/tests/data/c_resource_count/general/expected_diagnosticreport_month.csv
+++ b/tests/data/c_resource_count/general/expected_diagnosticreport_month.csv
@@ -1,5 +1,6 @@
 cnt,category,month,status
 2,cumulus__none,cumulus__none,cumulus__none
 1,cumulus__none,2022-09,cumulus__none
+1,cumulus__none,2021-02,partial
 1,CT,cumulus__none,cumulus__none
 1,CT,2023-10,cumulus__none

--- a/tests/data/c_resource_count/general/expected_diagnosticreport_year.csv
+++ b/tests/data/c_resource_count/general/expected_diagnosticreport_year.csv
@@ -1,5 +1,6 @@
 cnt,category,year,status
 2,cumulus__none,cumulus__none,cumulus__none
 1,cumulus__none,2022,cumulus__none
+1,cumulus__none,2021,partial
 1,CT,cumulus__none,cumulus__none
 1,CT,2023,cumulus__none

--- a/tests/data/c_resource_count/general/expected_documentreference_month.csv
+++ b/tests/data/c_resource_count/general/expected_documentreference_month.csv
@@ -1,5 +1,6 @@
 cnt,category,month,status
 2,cumulus__none,cumulus__none,cumulus__none
 1,cumulus__none,2022-09,cumulus__none
+1,cumulus__none,2020-11,superseded
 1,clinical-note,cumulus__none,cumulus__none
 1,clinical-note,2023-10,cumulus__none

--- a/tests/data/c_resource_count/general/expected_documentreference_year.csv
+++ b/tests/data/c_resource_count/general/expected_documentreference_year.csv
@@ -1,5 +1,6 @@
 cnt,category,year,status
 2,cumulus__none,cumulus__none,cumulus__none
 1,cumulus__none,2022,cumulus__none
+1,cumulus__none,2020,superseded
 1,clinical-note,cumulus__none,cumulus__none
 1,clinical-note,2023,cumulus__none

--- a/tests/data/c_resource_count/general/expected_immunization_month.csv
+++ b/tests/data/c_resource_count/general/expected_immunization_month.csv
@@ -2,3 +2,4 @@ cnt,month,status
 1,cumulus__none,cumulus__none
 1,2012-06,cumulus__none
 1,2011-08,cumulus__none
+1,2010-07,not-done

--- a/tests/data/c_resource_count/general/expected_immunization_year.csv
+++ b/tests/data/c_resource_count/general/expected_immunization_year.csv
@@ -2,3 +2,4 @@ cnt,year,status
 1,cumulus__none,cumulus__none
 1,2012,cumulus__none
 1,2011,cumulus__none
+1,2010,not-done

--- a/tests/data/c_resource_count/general/expected_observation_month.csv
+++ b/tests/data/c_resource_count/general/expected_observation_month.csv
@@ -4,4 +4,5 @@ cnt,category,month,status
 1,laboratory,2023-02,cumulus__none
 1,exam,2023-10,cumulus__none
 1,exam,2022-10,cumulus__none
+1,cumulus__none,2022-12,amended
 1,cumulus__none,2022-06,cumulus__none

--- a/tests/data/c_resource_count/general/expected_observation_year.csv
+++ b/tests/data/c_resource_count/general/expected_observation_year.csv
@@ -5,3 +5,4 @@ cnt,category,year,status
 1,exam,2023,cumulus__none
 1,exam,2022,cumulus__none
 1,cumulus__none,2022,cumulus__none
+1,cumulus__none,2022,amended

--- a/tests/data/c_resource_count/general/immunization/0.ndjson
+++ b/tests/data/c_resource_count/general/immunization/0.ndjson
@@ -1,3 +1,4 @@
 {"id": "with-date", "occurrenceDateTime": "2012-06-04"}
 {"id": "with-date2", "occurrenceDateTime": "2011-08-08"}
+{"id": "with-recorded", "recorded": "2010-07-04", "status": "not-done"}
 {"id": "no-date"}

--- a/tests/data/c_resource_count/general/observation/0.ndjson
+++ b/tests/data/c_resource_count/general/observation/0.ndjson
@@ -1,6 +1,7 @@
 {"id": "effectiveDateTime", "category": [{"coding": [{"code": "exam", "system": "http://terminology.hl7.org/CodeSystem/observation-category"}]}], "effectiveDateTime": "2023-10-04"}
 {"id": "effectivePeriod", "category": [{"coding": [{"code": "laboratory", "system": "http://terminology.hl7.org/CodeSystem/observation-category"}]}], "effectivePeriod": {"start": "2023-02-04"}}
 {"id": "effectiveInstant", "category": [{"coding": [{"code": "exam", "system": "http://terminology.hl7.org/CodeSystem/observation-category"}]}], "effectiveInstant": "2022-10-04"}
+{"id": "issued", "issued": "2022-12-14", "status": "amended"}
 {"id": "no-date", "category": [{"coding": [{"code": "procedure", "system": "http://terminology.hl7.org/CodeSystem/observation-category"}]}]}
 {"id": "unrelated-category", "category": [{"coding": [{"code": "nope", "system": "nope"}]}]}
 {"id": "no-category", "effectivePeriod": {"start": "2022-06-04"}}

--- a/tests/data/c_us_core_v4_count/general/expected_documentreference.csv
+++ b/tests/data/c_us_core_v4_count/general/expected_documentreference.csv
@@ -1,4 +1,4 @@
 cnt,valid_mandatory,year,status,valid_date,valid_author,valid_format,valid_encounter,valid_period
 1,true,cumulus__none,current,false,false,false,false,false
-1,true,2012,current,true,true,true,true,true
-1,false,2012,cumulus__none,true,true,true,true,true
+1,true,2014,current,true,true,true,true,true
+1,false,2014,cumulus__none,true,true,true,true,true


### PR DESCRIPTION
Specifically, the following extra fields are examined when pulling a date for cubes etc:
- DocumentReference.context.period.start
- DiagnosticReport.issued
- Immunization.recorded
- Observation.issued

Also fix a typo that prevented the aggregate output mode from taking effect.