### PR TITLE
fix: in allergy/condition must-support profiles, also check binding

### DIFF
--- a/cumulus_library_data_metrics/data_metrics/us_core_v4/allergyintolerance_must_support.jinja
+++ b/cumulus_library_data_metrics/data_metrics/us_core_v4/allergyintolerance_must_support.jinja
@@ -47,7 +47,16 @@ tmp_verification_flat AS {{
 tmp_verification AS (
     SELECT
         id,
-        BOOL_AND(tmp_verification_flat.code IS NOT NULL) AS valid_verification_status
+        -- This is a repeated check with the mandatory side.
+        -- We check the code binding on the mandatory side, since that's a required binding
+        -- and we like to validate those where possible.
+        -- But this field is really only a must-support field, so we also report it here.
+        BOOL_AND(
+            {{ utils.is_code_valid(
+                'tmp_verification_flat.code',
+                'unconfirmed | confirmed | refuted | entered-in-error'
+            ) }}
+        ) AS valid_verification_status
     FROM tmp_verification_flat
     GROUP BY id
 ),

--- a/cumulus_library_data_metrics/data_metrics/us_core_v4/condition_must_support.jinja
+++ b/cumulus_library_data_metrics/data_metrics/us_core_v4/condition_must_support.jinja
@@ -12,7 +12,16 @@ tmp_verification_flat AS {{
 tmp_verification AS (
     SELECT
         id,
-        BOOL_AND(tmp_verification_flat.code IS NOT NULL) AS valid_verification_status
+        -- This is a repeated check with the mandatory side.
+        -- We check the code binding on the mandatory side, since that's a required binding
+        -- and we like to validate those where possible.
+        -- But this field is really only a must-support field, so we also report it here.
+        BOOL_AND(
+            {{ utils.is_code_valid(
+                'tmp_verification_flat.code',
+                'unconfirmed | provisional | differential | confirmed | refuted | entered-in-error'
+            ) }}
+        ) AS valid_verification_status
     FROM tmp_verification_flat
     GROUP BY id
 ),


### PR DESCRIPTION
Something that came up while reviewing the metrics - we like to validate the specific codes in use, in addition to whether it's present or not.