### PR TITLE
c_term_coverage: add a few more system and OID nicknames

### DIFF
--- a/cumulus_library_data_metrics/data_metrics/c_term_coverage/c_term_coverage.jinja
+++ b/cumulus_library_data_metrics/data_metrics/c_term_coverage/c_term_coverage.jinja
@@ -32,21 +32,13 @@ src_systems_flat AS (
 src_systems_readable AS (
     SELECT
         id,
-        (
-            CASE
-            WHEN system = 'http://hl7.org/fhir/sid/cvx'
-            THEN 'CVX'
-            WHEN system = 'http://hl7.org/fhir/sid/ndc'
-            THEN 'NDC'
-            WHEN system = 'http://loinc.org'
-            THEN 'LOINC'
-            WHEN system = 'http://snomed.info/sct'
-            THEN 'SNOMED'
-            WHEN system = 'http://www.nlm.nih.gov/research/umls/rxnorm'
-            THEN 'RxNorm'
-            ELSE system
-            END
-        ) AS system
+        CASE
+        {% for url, name in system_names.items() %}
+        WHEN system = '{{ url }}'
+        THEN '{{ name }}'
+        {% endfor %}
+        ELSE system
+        END AS system
     FROM src_systems_flat
 ),
 src_systems AS (

--- a/cumulus_library_data_metrics/data_metrics/c_term_coverage/c_term_coverage.py
+++ b/cumulus_library_data_metrics/data_metrics/c_term_coverage/c_term_coverage.py
@@ -2,6 +2,7 @@
 
 from cumulus_library.base_table_builder import BaseTableBuilder
 
+from cumulus_library_data_metrics.data_metrics import systems
 from cumulus_library_data_metrics.data_metrics.base import MetricMixin
 
 # Note that this CUBE is already very large / slow.
@@ -14,7 +15,7 @@ class TermCoverageBuilder(MetricMixin, BaseTableBuilder):
 
     def make_table(self, **kwargs) -> None:
         """Make a single metric table"""
-        self.queries.append(self.render_sql(self.name, **kwargs))
+        self.queries.append(self.render_sql(self.name, system_names=systems.NAMES, **kwargs))
 
     def add_metric_queries(self) -> None:
         # https://github.com/sync-for-science/qualifier/blob/master/metrics.md#c_term_coverage-terminology-count-of-resources-by-terminology-system-by-resource-type-by-category
@@ -26,18 +27,18 @@ class TermCoverageBuilder(MetricMixin, BaseTableBuilder):
         self.make_table(
             src="Observation",
             field="code",
-            category_system="http://terminology.hl7.org/CodeSystem/observation-category",
+            category_system=systems.OBSERVATION_CATEGORY,
         )
         self.make_table(
             src="Observation",
             field="valueCodeableConcept",
-            category_system="http://terminology.hl7.org/CodeSystem/observation-category",
+            category_system=systems.OBSERVATION_CATEGORY,
         )
         self.make_table(src="AllergyIntolerance", field="code")
         self.make_table(
             src="Condition",
             field="code",
-            category_system="http://terminology.hl7.org/CodeSystem/condition-category",
+            category_system=systems.CONDITION_CATEGORY,
         )
         self.make_table(src="Device", field="type")
         self.make_table(src="DiagnosticReport", field="code")

--- a/cumulus_library_data_metrics/data_metrics/q_term_use/q_term_use.py
+++ b/cumulus_library_data_metrics/data_metrics/q_term_use/q_term_use.py
@@ -2,6 +2,7 @@
 
 from cumulus_library.base_table_builder import BaseTableBuilder
 
+from cumulus_library_data_metrics.data_metrics import systems
 from cumulus_library_data_metrics.data_metrics.base import MetricMixin
 
 
@@ -22,59 +23,44 @@ class TermUseBuilder(MetricMixin, BaseTableBuilder):
         self.make_table(
             src="AllergyIntolerance",
             field="code",
-            systems=[
-                "http://snomed.info/sct",
-                "http://www.nlm.nih.gov/research/umls/rxnorm",
-            ],
+            systems=[systems.RXNORM, systems.SNOMED],
         )
         self.make_table(
             src="Condition",
             field="code",
-            systems=[
-                "http://hl7.org/fhir/sid/icd-10-cm",
-                "http://hl7.org/fhir/sid/icd-9-cm",
-                "http://snomed.info/sct",
-            ],
+            systems=[systems.ICD9CM, systems.ICD10CM, systems.SNOMED],
         )
-        self.make_table(src="Device", field="type", systems=["http://snomed.info/sct"])
-        self.make_table(src="DiagnosticReport", field="code", systems=["http://loinc.org"])
-        self.make_table(src="DocumentReference", field="type", systems=["http://loinc.org"])
+        self.make_table(src="Device", field="type", systems=[systems.SNOMED])
+        self.make_table(src="DiagnosticReport", field="code", systems=[systems.LOINC])
+        self.make_table(src="DocumentReference", field="type", systems=[systems.LOINC])
         self.make_table(
             src="Immunization",
             field="vaccineCode",
-            systems=[
-                # The FHIR spec also gives urn:oid:1.2.36.1.2001.1005.17 as an example,
-                # but the US Core profile drops that suggestion in favor of only CVX.
-                "http://hl7.org/fhir/sid/cvx",
-            ],
+            # The FHIR spec also gives urn:oid:1.2.36.1.2001.1005.17 as an example,
+            # but the US Core profile drops that suggestion in favor of only CVX.
+            systems=[systems.CVX],
         )
         self.make_table(
             src="Medication",
             field="code",
-            systems=[
-                # The FHIR spec gives SNOMED as an example, but the US Core profile drops that
-                # suggestion in favor of only RxNorm
-                "http://www.nlm.nih.gov/research/umls/rxnorm",
-            ],
+            # The FHIR spec gives SNOMED as an example, but the US Core profile drops that
+            # suggestion in favor of only RxNorm
+            systems=[systems.RXNORM],
         )
         self.make_table(
             src="MedicationRequest",
             field="medicationCodeableConcept",
-            systems=[
-                # The FHIR spec gives SNOMED as an example, but the US Core profile drops that
-                # suggestion in favor of only RxNorm
-                "http://www.nlm.nih.gov/research/umls/rxnorm",
-            ],
+            # The FHIR spec gives SNOMED as an example, but the US Core profile drops that
+            # suggestion in favor of only RxNorm
+            systems=[systems.RXNORM],
         )
-        self.make_table(src="Observation", field="code", systems=["http://loinc.org"])
+        self.make_table(src="Observation", field="code", systems=[systems.LOINC])
         self.make_table(
             src="Observation",
             field="valueCodeableConcept",
-            systems=[
-                # Base FHIR doesn't suggest anything specific here, but the Laboratory and
-                # Smoking Status profiles both want SNOMED.
-                "http://snomed.info/sct",
-            ],
+            # Base FHIR doesn't suggest anything specific here, but the Laboratory and
+            # Smoking Status profiles both want SNOMED.
+            systems=[systems.SNOMED],
         )
         self.make_table(
             src="Procedure",
@@ -82,10 +68,10 @@ class TermUseBuilder(MetricMixin, BaseTableBuilder):
             systems=[
                 # Base FHIR only gives SNOMED as an example,
                 # but the US Core v4 profile lists all these.
-                "http://loinc.org",
-                "http://snomed.info/sct",
+                systems.CPT,
+                systems.LOINC,
+                systems.SNOMED,
                 "http://www.ada.org/cdt",
-                "http://www.ama-assn.org/go/cpt",
                 "https://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets",
                 "http://www.cms.gov/Medicare/Coding/ICD10",
             ],

--- a/cumulus_library_data_metrics/data_metrics/resource_info.py
+++ b/cumulus_library_data_metrics/data_metrics/resource_info.py
@@ -1,5 +1,7 @@
 """Holds various static info about resources we want to examine."""
 
+from cumulus_library_data_metrics.data_metrics import systems
+
 # Categories to slice on
 CATEGORIES = {
     "AllergyIntolerance": {
@@ -7,32 +9,27 @@ CATEGORIES = {
     },
     "Condition": {
         "cat_field": "category",
-        "cat_systems": ["http://terminology.hl7.org/CodeSystem/condition-category"],
+        "cat_systems": [systems.CONDITION_CATEGORY],
     },
     "DiagnosticReport": {
         "cat_field": "category",
-        "cat_systems": [
-            "http://loinc.org",
-            "http://terminology.hl7.org/CodeSystem/v2-0074",
-        ],
+        "cat_systems": [systems.LOINC, systems.DIAGNOSTIC_SECTION],
     },
     "DocumentReference": {
         "cat_field": "category",
-        "cat_systems": [
-            "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category"
-        ],
+        "cat_systems": [systems.USCORE_DOCREF_CATEGORY],
     },
     "Encounter": {
         "cat_field": "type",
-        "cat_systems": ["http://www.ama-assn.org/go/cpt", "http://snomed.info/sct"],
+        "cat_systems": [systems.CPT, systems.SNOMED],
     },
     "MedicationRequest": {
         "cat_field": "category",
-        "cat_systems": ["http://terminology.hl7.org/CodeSystem/medicationrequest-category"],
+        "cat_systems": [systems.MEDREQ_CATEGORY],
     },
     "Observation": {
         "cat_field": "category",
-        "cat_systems": ["http://terminology.hl7.org/CodeSystem/observation-category"],
+        "cat_systems": [systems.OBSERVATION_CATEGORY],
     },
 }
 

--- a/cumulus_library_data_metrics/data_metrics/systems.py
+++ b/cumulus_library_data_metrics/data_metrics/systems.py
@@ -1,0 +1,54 @@
+"""Terminology system constants and information."""
+
+CPT = "http://www.ama-assn.org/go/cpt"
+CVX = "http://hl7.org/fhir/sid/cvx"
+ICD9CM = "http://hl7.org/fhir/sid/icd-9-cm"
+ICD10CM = "http://hl7.org/fhir/sid/icd-10-cm"
+LOINC = "http://loinc.org"
+NDC = "http://hl7.org/fhir/sid/ndc"
+RXNORM = "http://www.nlm.nih.gov/research/umls/rxnorm"
+SNOMED = "http://snomed.info/sct"
+UCUM = "http://unitsofmeasure.org"
+
+# Resource-specific systems
+CONDITION_CATEGORY = "http://terminology.hl7.org/CodeSystem/condition-category"
+DIAGNOSTIC_SECTION = "http://terminology.hl7.org/CodeSystem/v2-0074"
+MEDREQ_CATEGORY = "http://terminology.hl7.org/CodeSystem/medicationrequest-category"
+OBSERVATION_CATEGORY = "http://terminology.hl7.org/CodeSystem/observation-category"
+USCORE_DOCREF_CATEGORY = "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category"
+
+# Object Identifiers (OIDs).
+# FHIR does not like to see them used (instead the http URL should be used).
+# But some EHRs really like OIDs and may use them anyway.
+# In terms of data metrics - we do not allow OIDs for any kind of validation
+# or quality metrics. But for characterization metrics, we do look for them.
+# See:
+# https://www.hl7.org/fhir/R4/terminologies.html#system
+# https://www.hl7.org/fhir/R4/terminologies-systems.html
+OIDS = {
+    CPT: "urn:oid:2.16.840.1.113883.6.12",
+    CVX: "urn:oid:2.16.840.1.113883.12.292",
+    ICD9CM: "urn:oid:2.16.840.1.113883.6.2",
+    ICD10CM: "urn:oid:2.16.840.1.113883.6.90",
+    LOINC: "urn:oid:2.16.840.1.113883.6.1",
+    NDC: "urn:oid:2.16.840.1.113883.6.69",
+    RXNORM: "urn:oid:2.16.840.1.113883.6.88",
+    SNOMED: "urn:oid:2.16.840.1.113883.6.96",
+    UCUM: "urn:oid:2.16.840.1.113883.6.8",
+}
+
+NAMES = {
+    CPT: "CPT",
+    CVX: "CVX",
+    ICD9CM: "ICD-9-CM",
+    ICD10CM: "ICD-10-CM",
+    LOINC: "LOINC",
+    NDC: "NDC",
+    RXNORM: "RxNorm",
+    SNOMED: "SNOMED",
+    UCUM: "UCUM",
+}
+# Add all the OID versions too
+for system, oid_system in OIDS.items():
+    if system in NAMES:
+        NAMES[oid_system] = f"{NAMES[system]} (OID)"

--- a/tests/data/c_term_coverage/general/allergyintolerance/0.ndjson
+++ b/tests/data/c_term_coverage/general/allergyintolerance/0.ndjson
@@ -1,5 +1,6 @@
 {"id": "snomed", "code": {"coding": [{"system": "http://snomed.info/sct"}]}}
 {"id": "snomed-with-text", "code": {"coding": [{"system": "http://snomed.info/sct"}], "text": "hello"}}
+{"id": "snomed-oid", "code": {"coding": [{"system": "urn:oid:2.16.840.1.113883.6.96"}]}}
 {"id": "multiple-systems", "code": {"coding": [{"code": "boo"}, {"system": "http://other"}, {"system": "http://loinc.org"}], "text": "\u0000"}}
 {"id": "repeated-systems", "code": {"coding": [{"system": "http://other"}, {"system": "http://other"}, {"system": "http://www.nlm.nih.gov/research/umls/rxnorm"}]}}
 {"id": "no-system", "code": {"coding": [{"code": "boo"}]}}

--- a/tests/data/c_term_coverage/general/expected_allergyintolerance_code.csv
+++ b/tests/data/c_term_coverage/general/expected_allergyintolerance_code.csv
@@ -3,5 +3,6 @@ cnt,systems,status,year
 2,SNOMED,cumulus__none,cumulus__none
 1,other,cumulus__none,2018
 1,other,confirmed,cumulus__none
+1,SNOMED (OID),cumulus__none,cumulus__none
 1,RxNorm; http://other,cumulus__none,cumulus__none
 1,LOINC; http://other,cumulus__none,cumulus__none


### PR DESCRIPTION
This adds CPT, ICD9CM, ICD10CM, and UCUM systems to the metric's short names, as well as OID versions of each system.

With this change, for example:
- "http://unitsofmeasure.org" -> "UCUM"
- "urn:oid:2.16.840.1.113883.6.8" -> "UCUM (OID)"

Plus a little bit of system string refactoring to avoid repeating strings that are easy to typo.