### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/cumulus_library_data_metrics/__init__.py
+++ b/cumulus_library_data_metrics/__init__.py
@@ -1,3 +1,3 @@
 """Data Metrics study for Cumulus Library"""
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"


### PR DESCRIPTION
Breaking changes since 1.0.0:
- Renamed c_term_coverage -> c_system_use
- Renamed q_term_use -> q_system_use
- All q_* summary percentages are now floats not strings

Other important changes since 1.0.0:
- Added DiagnosticReport Lab profile
- Adjusted DiagnosticReport Note profile to not cover labs anymore
- Add more date fields to all date stratifications
- Add deceased column to c_pt_count
- Changed denominator logic for q_ref_target_valid