### PR TITLE
fix(q_date_recent): quote "end" for Athena

### DIFF
--- a/cumulus_library_data_metrics/__init__.py
+++ b/cumulus_library_data_metrics/__init__.py
@@ -1,3 +1,3 @@
 """Data Metrics study for Cumulus Library"""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/cumulus_library_data_metrics/q_date_recent/q_date_recent.jinja
+++ b/cumulus_library_data_metrics/q_date_recent/q_date_recent.jinja
@@ -8,7 +8,7 @@ SELECT
     src.id,
 
     {% for field in fields %}
-    src.{{ field }} AS {{ field|replace('.', '_')|lower }},
+    src.{{ utils.quote_field(field) }} AS {{ field|replace('.', '_')|lower }},
     {% endfor %}
 
     src_status.status
@@ -33,7 +33,7 @@ WHERE
         FALSE
         {% for field in fields %}
         OR (
-            {{ field }} IS NOT NULL
+            {{ utils.quote_field(field) }} IS NOT NULL
             AND {{ utils.coalesce_date([field]) }} NOT BETWEEN DATE('1900-01-01') AND CURRENT_DATE
         )
         {% endfor %}

--- a/cumulus_library_data_metrics/utils.jinja
+++ b/cumulus_library_data_metrics/utils.jinja
@@ -118,6 +118,12 @@
 {%- endmacro %}
 
 
+-- Quotes a field that may include keywords and periods (like src.end -> "src"."end")
+{% macro quote_field(field) -%}
+    "{{ field|replace('.', '"."') }}"
+{%- endmacro %}
+
+
 -- Extracts a date field from a list of choices and returns a DATE.
 {% macro coalesce_date(fields) -%}
     date(from_iso8601_timestamp(


### PR DESCRIPTION
This is a follow-on to a [previous commit](https://github.com/smart-on-fhir/cumulus-library-data-metrics/commit/1f315f71000602a14b74d1dbe49edd7d9d42b660) that also quoted end, but this catches a few more cases.

I guess I just didn't test in Athena again after that previous fix...?  Just assumed I got it? Seems like a bad look for me.

And bump version to 2.0.1