### PR TITLE
c_us_core_v4_count: add a couple missing Encounter must-support fields

### DIFF
--- a/cumulus_library_data_metrics/us_core_v4/encounter_must_support.jinja
+++ b/cumulus_library_data_metrics/us_core_v4/encounter_must_support.jinja
@@ -20,12 +20,34 @@ tmp_locations AS (
     GROUP BY id
 ),
 
+tmp_reason_references AS (
+    SELECT
+        id,
+        BOOL_AND({{ utils.is_reference_of_type('u.reasonReference', [
+            'Condition',
+            'Procedure',
+            'Observation',
+            'ImmunizationRecommendation',
+        ]) }}) as valid_reason_reference
+    FROM {{ src }},
+        UNNEST(reasonReference) AS u (reasonReference)
+    GROUP BY id
+),
+
 tmp_simplified AS (
     SELECT
         src.id,
         participant IS NOT NULL AS valid_participant, -- array
         {{ utils.is_period_valid('period') }} AS valid_period,
-        reasonCode IS NOT NULL AS valid_reason_code, -- array
+        reasonCode IS NOT NULL -- array
+        OR (
+            -- The US Core profile also changes the cardinality from
+            -- 0..* to 0..1 but that is apparently a mistake in v4:
+            -- https://jira.hl7.org/browse/FHIR-36862
+            -- So we don't enforce that "at most 1" requirement.
+            tmp_reason_references.valid_reason_reference IS NOT NULL
+            AND tmp_reason_references.valid_reason_reference
+        ) AS valid_reason,
         (
             {% if schema["hospitalization"]["dischargeDisposition"] %}
             {{ utils.is_concept_valid('hospitalization.dischargeDisposition') }}
@@ -33,20 +55,23 @@ tmp_simplified AS (
             FALSE
             {% endif %}
         ) AS valid_discharge_disposition,
-        (
+        {{ utils.is_reference_of_type('serviceProvider', 'Organization') }}
+        OR (
             tmp_locations.valid_location IS NOT NULL
             AND tmp_locations.valid_location
         ) AS valid_location
     FROM {{ src }} AS src
     LEFT JOIN tmp_locations
     ON src.id = tmp_locations.id
+    LEFT JOIN tmp_reason_references
+    ON tmp_reason_references.id = src.id
 )
 
 {%
 set ns.fields = [
     'valid_participant',
     'valid_period',
-    'valid_reason_code',
+    'valid_reason',
     'valid_discharge_disposition',
     'valid_location',
 ]

--- a/tests/data/t_us_core_v4/encounter-low-schema/expected_encounter_must_support.csv
+++ b/tests/data/t_us_core_v4/encounter-low-schema/expected_encounter_must_support.csv
@@ -1,2 +1,2 @@
-id,valid_participant,valid_period,valid_reason_code,valid_discharge_disposition,valid_location,valid
+id,valid_participant,valid_period,valid_reason,valid_discharge_disposition,valid_location,valid
 nothing,false,false,false,false,false,false

--- a/tests/data/t_us_core_v4/must-support/encounter/0.ndjson
+++ b/tests/data/t_us_core_v4/must-support/encounter/0.ndjson
@@ -2,4 +2,10 @@
 {"id": "hospitalization-no-disposition", "hospitalization": {"reAdmission": {"text": "X"}}}
 {"id": "location-multiple-good", "location": [{"location": {"reference": "Location/A"}}, {"location": {"reference": "Location/B"}}]}
 {"id": "location-multiple-bad", "location": [{"location": {"reference": "Location/A"}}, {"status": "active"}]}
+{"id": "reason-ref-good", "reasonReference": [{"reference": "Condition/A"}]}
+{"id": "reason-ref-multiple-good", "reasonReference": [{"reference": "Condition/A"}, {"reference": "Condition/B"}]}
+{"id": "reason-ref-multiple-bad", "reasonReference": [{"reference": "Condition/A"}, {"reference": "Patient/B"}]}
+{"id": "reason-ref-wrong-target", "reasonReference": [{"reference": "Patient/A"}]}
+{"id": "service-provider-good", "serviceProvider": {"reference": "Organization/A"}}
+{"id": "service-provider-wrong-target", "serviceProvider": {"reference": "Patient/A"}}
 {"id": "nothing"}

--- a/tests/data/t_us_core_v4/must-support/expected_encounter_must_support.csv
+++ b/tests/data/t_us_core_v4/must-support/expected_encounter_must_support.csv
@@ -1,5 +1,11 @@
-id,valid_participant,valid_period,valid_reason_code,valid_discharge_disposition,valid_location,valid
+id,valid_participant,valid_period,valid_reason,valid_discharge_disposition,valid_location,valid
 valid,true,true,true,true,true,true
+service-provider-wrong-target,false,false,false,false,false,false
+service-provider-good,false,false,false,false,true,false
+reason-ref-wrong-target,false,false,false,false,false,false
+reason-ref-multiple-good,false,false,true,false,false,false
+reason-ref-multiple-bad,false,false,false,false,false,false
+reason-ref-good,false,false,true,false,false,false
 nothing,false,false,false,false,false,false
 location-multiple-good,false,false,false,false,true,false
 location-multiple-bad,false,false,false,false,false,false


### PR DESCRIPTION
There were two Encounter must-support fields that I originally missed. They are alternative fields:
- reasonReference can be defined instead of reasonCode
- serviceProvider can be defined instead of location.location

This commit now checks for both choices for each requirement (reason & location).

This has the arguably breaking change of renaming a field - I think I have some more breaking changes coming to split up some tables into two. I'll figure out the version once I'm closer to release.