### PR TITLE
q_system_use: ignore codeable concepts that are all nulls inside

### DIFF
--- a/cumulus_library_data_metrics/q_system_use/q_system_use.jinja
+++ b/cumulus_library_data_metrics/q_system_use/q_system_use.jinja
@@ -36,7 +36,7 @@ SELECT
     {{ field }}
 FROM rejoined_src
 WHERE
-    {{ field }} IS NOT NULL
+    {{ utils.is_concept_valid(field) }}
     AND (
         has_target_system IS NULL
         OR NOT has_target_system

--- a/tests/data/q_system_use/general/expected_procedure_code.csv
+++ b/tests/data/q_system_use/general/expected_procedure_code.csv
@@ -1,0 +1,5 @@
+id,status,code
+missing-system,,"{'id': NULL, 'coding': [{'id': NULL, 'code': NULL, 'display': No system, 'system': NULL, 'userSelected': NULL, 'version': NULL}], 'text': NULL}"
+missing-coding,,"{'id': NULL, 'coding': NULL, 'text': No coding}"
+empty-coding,,"{'id': NULL, 'coding': [], 'text': NULL}"
+bad-system,,"{'id': NULL, 'coding': [{'id': NULL, 'code': NULL, 'display': NULL, 'system': nope, 'userSelected': NULL, 'version': NULL}], 'text': NULL}"

--- a/tests/data/q_system_use/general/expected_summary.csv
+++ b/tests/data/q_system_use/general/expected_summary.csv
@@ -1,7 +1,7 @@
 resource,field,numerator,denominator,percentage
 # Various edge cases here in procedure
-Procedure,cumulus__all,4,12,33.33
-Procedure,code,4,12,33.33
+Procedure,cumulus__all,4,13,30.77
+Procedure,code,4,13,30.77
 # Rest are often short happy-path checks to confirm that we look at the right json field
 Observation,valueCodeableConcept,0,2,0.00
 Observation,cumulus__all,0,2,0.00

--- a/tests/data/q_system_use/general/procedure/0.ndjson
+++ b/tests/data/q_system_use/general/procedure/0.ndjson
@@ -9,4 +9,5 @@
 {"resourceType": "Procedure", "id": "missing-system", "code": {"coding": [{"display": "No system"}]}}
 {"resourceType": "Procedure", "id": "empty-coding", "code": {"coding": []}}
 {"resourceType": "Procedure", "id": "missing-coding", "code": {"text": "No coding"}}
+{"resourceType": "Procedure", "id": "invalid-code", "code": {"id": "no content"}}
 {"resourceType": "Procedure", "id": "missing-code"}


### PR DESCRIPTION
Instead of checking "concept is not null" we should instead be using "utils.is_concept_valid()" because we want to ignore concepts that look like:

`{coding=null, id=null, text=null}`

which is what we can get with the fully-specified schema that Cumulus uses.