### PR TITLE
feat: support --option output-mode:aggregate in addition to env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,9 @@ cumulus-library export \
 This study generates `CUBE` output by default.
 If it's easier to work with simple aggregate counts of every value combination
 (that is, without the partial value combinations that `CUBE()` generates),
-run the build step with `DATA_METRICS_OUTPUT_MODE=aggregate` in your environment.
+run the build step with `--option output-mode:aggregate`.
 
 That is, run it like:
 ```sh
-env \
-  DATA_METRICS_OUTPUT_MODE=aggregate \
-  cumulus-library build ...
+cumulus-library build --option output-mode:aggregate ...
 ```

--- a/cumulus_library_data_metrics/c_us_core_v4_count/c_us_core_v4_count.py
+++ b/cumulus_library_data_metrics/c_us_core_v4_count/c_us_core_v4_count.py
@@ -17,7 +17,7 @@ class UsCoreV4CountBuilder(UsCoreV4Mixin, BaseTableBuilder):
         # at a metric like this one with both mandatory and must-support fields.
         kwargs["skip_duplicated_mandatory_checks"] = True
 
-        if self.get_output_mode() == "cube" and "mandatory_split" in kwargs:
+        if self.output_mode == "cube" and "mandatory_split" in kwargs:
             kwargs["table_max"] = kwargs["mandatory_split"]
             self.queries += [
                 self.render_sql("mandatory", table_num=i + 1, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "cumulus-library-data-metrics"
 requires-python = ">= 3.10"
 dependencies = [
-    "cumulus-library >= 2.2, < 3",
+    "cumulus-library >= 2.3, < 3",
 ]
 description = "Data quality and characterization metrics for Cumulus"
 readme = "README.md"


### PR DESCRIPTION
There are now two ways to set the output mode:
CLI: --option output-mode:aggregate
ENV: DATA_METRICS_OUTPUT_MODE=aggregate

This also bumps the minimum Library version to 2.3