### PR TITLE
Cap max_date in the meta_date table to avoid Pandas bug

### DIFF
--- a/cumulus_library_data_metrics/__init__.py
+++ b/cumulus_library_data_metrics/__init__.py
@@ -1,3 +1,3 @@
 """Data Metrics study for Cumulus Library"""
 
-__version__ = "5.0.1"
+__version__ = "5.1.0"

--- a/cumulus_library_data_metrics/meta/dates.jinja
+++ b/cumulus_library_data_metrics/meta/dates.jinja
@@ -43,7 +43,11 @@ unified AS (
 
 SELECT
     MIN(min_date) AS min_date,
-    MAX(max_date) AS max_date
+    -- Cap max_date to NOW because (A) it's not entirely accurate to say this study goes to the
+    -- year 2990 just because someone makes a typo and (B) Pandas has issues with parsing dates
+    -- past 2262 by default (search "timestamp limitations" in pandas docs) and gets confused
+    -- when exporting this table.
+    LEAST(MAX(max_date), CURRENT_DATE) AS max_date
 FROM unified
 
 );


### PR DESCRIPTION
It can't represent dates past 2262, which we sometimes have due to typos etc.

Plus, it doesn't really makes sense to say that a run of the data metrics covers data in the future.

So instead, we cap to CURRENT_DATE. No fix yet for typos deep in the past.