### PR TITLE
Handle empty schemas better

### DIFF
--- a/cumulus_library_data_metrics/us_core_v4/documentreference_mandatory.jinja
+++ b/cumulus_library_data_metrics/us_core_v4/documentreference_mandatory.jinja
@@ -13,7 +13,7 @@ tmp_attachment_flat AS (
         {% if schema["content"]["attachment"] %}
         u.content.attachment.contenttype
         {% else %}
-        NULL AS contenttype
+        CAST(NULL AS VARCHAR) AS contenttype
         {% endif %}
 
     FROM {{ src }},

--- a/cumulus_library_data_metrics/us_core_v4/documentreference_must_support.jinja
+++ b/cumulus_library_data_metrics/us_core_v4/documentreference_must_support.jinja
@@ -7,16 +7,11 @@
 
 WITH
 
+{% if schema["content"]["format"] %}
 tmp_content_flat AS (
     SELECT
         id,
-
-        {% if schema["content"]["format"] %}
         u.content.format
-        {% else %}
-        NULL AS format
-        {% endif %}
-
     FROM {{ src }},
         UNNEST(content) AS u (content)
 ),
@@ -27,6 +22,11 @@ tmp_content_grouped AS (
     FROM tmp_content_flat
     GROUP BY id
 ),
+{% else %}
+tmp_content_grouped AS (
+    SELECT id, FALSE AS valid_format FROM {{ src }} WHERE 1=0  -- return an empty table
+),
+{% endif %}
 
 tmp_encounters AS (
     SELECT


### PR DESCRIPTION
On Athena, referencing a NULL as a struct does not work (but it does in DuckDB, annoyingly - so this is hard to unit test).

Rule of thumb: don't have any bare "NULL AS field_name" lines - always have a CAST(NULL AS ...) bit there.