### PR TITLE
feat(q_system_use): add Encounter.class to the metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Cumulus-based implementation of the [qualifier metrics](https://github.com/syn
 
 ## Implemented Metrics
 
-The following qualifier metrics are implemented (per February 2025 qualifer definitions).
+The following qualifier metrics are implemented (per May 2025 qualifer definitions).
 
 - [c_attachment_count](https://github.com/sync-for-science/qualifier/blob/master/metrics.md#c_attachment_count)
 - [c_content_type_use](https://github.com/sync-for-science/qualifier/blob/master/metrics.md#c_content_type_use)

--- a/cumulus_library_data_metrics/q_system_use/q_system_use.jinja
+++ b/cumulus_library_data_metrics/q_system_use/q_system_use.jinja
@@ -6,12 +6,19 @@ CREATE TABLE {{ study_prefix }}__q_system_use_{{ src|lower }}_{{ field|lower }} 
 WITH
 -- Look for target systems
 src_has_system AS (
+{% if is_coding %}
+    SELECT
+        id,
+        {{ field }}.system IN {{ system_list }} AS has_target_system
+    FROM {{ src }}
+{% else %}
     SELECT
         id,
         BOOL_OR(c.coding.system IN {{ system_list }}) AS has_target_system
     FROM {{ src }},
         UNNEST({{ field }}.coding) AS c (coding)
     GROUP BY id
+{% endif %}
 ),
 
 -- Left join back to src to catch all rows, not just those with codings
@@ -32,7 +39,11 @@ SELECT
     {{ field }}
 FROM rejoined_src
 WHERE
+{% if is_coding %}
+    {{ utils.is_coding_valid(field) }}
+{% else %}
     {{ utils.is_concept_valid(field) }}
+{% endif %}
     AND (
         has_target_system IS NULL
         OR NOT has_target_system

--- a/cumulus_library_data_metrics/q_system_use/q_system_use.py
+++ b/cumulus_library_data_metrics/q_system_use/q_system_use.py
@@ -31,6 +31,12 @@ class SystemUseBuilder(MetricMixin, cumulus_library.BaseTableBuilder):
             src="DocumentReference", field="type", systems=[systems.LOINC, systems.NULL_FLAVOR]
         )
         self.make_table(
+            src="Encounter",
+            field="class",
+            systems=[systems.ENCOUNTER_CLASS],
+            is_coding=True,
+        )
+        self.make_table(
             src="Immunization",
             field="vaccineCode",
             # The FHIR spec also gives urn:oid:1.2.36.1.2001.1005.17 as an example,

--- a/tests/data/q_system_use/general/Encounter.ndjson
+++ b/tests/data/q_system_use/general/Encounter.ndjson
@@ -1,0 +1,1 @@
+{"resourceType": "Encounter", "id": "basic", "class": {"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"}}

--- a/tests/data/q_system_use/general/expected_summary.csv
+++ b/tests/data/q_system_use/general/expected_summary.csv
@@ -12,6 +12,8 @@ Medication,cumulus__all,0,1,0.00
 Medication,code,0,1,0.00
 Immunization,vaccineCode,0,1,0.00
 Immunization,cumulus__all,0,1,0.00
+Encounter,cumulus__all,0,1,0.00
+Encounter,class,0,1,0.00
 DocumentReference,type,1,3,33.33
 DocumentReference,cumulus__all,1,3,33.33
 DiagnosticReport,cumulus__all,0,1,0.00


### PR DESCRIPTION
Where we are looking for the standard v3-ActCode system.

Matches [changes](https://github.com/sync-for-science/qualifier/pull/11) in the qualifer repo. (I'll wait to land this until the qualifer change is accepted)