### PR TITLE
fix: allow system-only codings

### DIFF
--- a/cumulus_library_data_metrics/utils.jinja
+++ b/cumulus_library_data_metrics/utils.jinja
@@ -306,6 +306,7 @@ WHERE cnt >= {{ min_bucket_size }}
     {{ field }} IS NOT NULL
     AND (
         {{ field }}.code IS NOT NULL
+        OR {{ field }}.system IS NOT NULL
         OR {{ is_string_valid(field + '.display') }}
     )
 )

--- a/tests/data/t_us_core_v4/mandatory/encounter/0.ndjson
+++ b/tests/data/t_us_core_v4/mandatory/encounter/0.ndjson
@@ -1,6 +1,7 @@
 {"resourceType": "Encounter", "id": "valid", "status": "finished", "class": {"display": "X"}, "type": [], "subject": {"reference": "Patient/A"}}
 {"resourceType": "Encounter", "id": "no-status", "class": {"display": "X"}, "type": [], "subject": {"reference": "Patient/A"}}
 {"resourceType": "Encounter", "id": "no-class", "status": "finished", "type": [], "subject": {"reference": "Patient/A"}}
+{"resourceType": "Encounter", "id": "system-only-class", "class": {"system": "some-system"}}
 {"resourceType": "Encounter", "id": "empty-class", "status": "finished", "class": {}, "type": [], "subject": {"reference": "Patient/A"}}
 {"resourceType": "Encounter", "id": "no-type", "status": "finished", "class": {"display": "X"}, "subject": {"reference": "Patient/A"}}
 {"resourceType": "Encounter", "id": "no-subject", "status": "finished", "class": {"display": "X"}, "type": []}

--- a/tests/data/t_us_core_v4/mandatory/expected_encounter_mandatory.csv
+++ b/tests/data/t_us_core_v4/mandatory/expected_encounter_mandatory.csv
@@ -1,5 +1,6 @@
 id,valid_status,valid_class,valid_type,valid_subject,valid,status
 valid,true,true,true,true,true,finished
+system-only-class,false,true,false,false,false,
 nothing,false,false,false,false,false,
 no-type,true,true,false,true,false,finished
 no-subject,true,true,true,false,false,finished


### PR DESCRIPTION
This was surfaced after we started stripping codes and displays from certain Epic-internal codings. We would fail Encounter.class (which is a Coding) on q_valid_us_core_v4 because we wouldn't consider it filled in.

But... we were being more strict for Codings than we were for CodeableConcepts, where we just required that any Codings were defined underneath it at all, system-only or otherwise. Likewise, the spec actually does suggest that system-only Codings are a real and (kinda) meaningful state:

> If the system is present, and there is no code, then this is
> understood to mean that there is no suitable code in the system
> in which to represent the code.

So... let's allow it. This will fix our bogus failures at least.